### PR TITLE
More accurate timezone change check

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,16 +10,20 @@
     and ansible_distribution_version < 7
 
 - block:
-  - name: Check current timezone
+  - name: Check current timezone value
+    command: timedatectl show --va -p Timezone
+    changed_when: false
+    register: current_timezone_value
+  - name: Set Timezone value
+    command: timedatectl set-timezone {{ timezone }}
+    when: "timezone not in current_timezone_value.stdout"
+  - name: Check NTP status
     command: timedatectl status
     changed_when: false
-    register: current_timezone
-  - name: Set Timezone
-    command: timedatectl set-timezone {{ timezone }}
-    when: "'Time zone: {{ timezone }}' not in current_timezone.stdout"
+    register: current_timezone_status
   - name: Enable ntp
     command: timedatectl set-ntp true
-    when: "enable_ntp and 'Network time on: no' in current_timezone.stdout"
+    when: "enable_ntp and 'Network time on: no' in current_timezone_status.stdout"
   when: >
     ansible_distribution not in ('CentOS', 'Red Hat Enterprise Linux') or
     ansible_distribution in ('CentOS', 'Red Hat Enterprise Linux') and

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,7 +16,7 @@
     register: current_timezone
   - name: Set Timezone
     command: timedatectl set-timezone {{ timezone }}
-    when: "'{{ timezone }}' not in current_timezone.stdout"
+    when: "'Time zone: {{ timezone }}' not in current_timezone.stdout"
   - name: Enable ntp
     command: timedatectl set-ntp true
     when: "enable_ntp and 'Network time on: no' in current_timezone.stdout"


### PR DESCRIPTION
Trying to change my timezone from `America/New_York` to `UTC` does not do anything, because the `when` condition checks if `UTC` us within `stdout` which it will always be due to the suffix on the `Universal time` line.

```
$ sudo timedatectl status
               Local time: Fri 2022-06-03 08:54:45 EDT
           Universal time: Fri 2022-06-03 12:54:45 UTC
                 RTC time: Fri 2022-06-03 12:54:45
                Time zone: America/New_York (EDT, -0400)
System clock synchronized: yes
              NTP service: inactive
          RTC in local TZ: no
```